### PR TITLE
Release 1.0.5

### DIFF
--- a/src/components/Editor/plugins/OverrideEnterKeyPlugin.tsx
+++ b/src/components/Editor/plugins/OverrideEnterKeyPlugin.tsx
@@ -18,7 +18,7 @@ export function OverrideEnterKeyPlugin({
       payload => {
         const event = payload as KeyboardEvent;
         event.preventDefault();
-        if (event.ctrlKey) {
+        if (event.ctrlKey || event.shiftKey) {
           return false;
         }
         onEnterKeyPress();


### PR DESCRIPTION
- Fixed placeholder not being shown once editor gets closed
- Added 2 style props to customize read only box and editor placeholder
- Fixed issue with link input that when clicked editor was being closed
- Added shift + enter as an option to generate a new line if using OverrideKeyEnterPlugin