### PR TITLE
Feat/allow links prop

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -240,15 +240,17 @@ export function Editor({
 
   useEffect(() => {
     if (editMode) {
-      // add click event listener to body
+      // Use mousedown instead of click so drag-selections starting inside the
+      // editor don't close it when the user releases the mouse outside the
+      // editor bounds. mousedown's target is where the press began.
       setTimeout(() => {
-        document.body.addEventListener('click', handleCustomBlur);
+        document.body.addEventListener('mousedown', handleCustomBlur);
       }, 400);
     } else {
-      document.body.removeEventListener('click', handleCustomBlur);
+      document.body.removeEventListener('mousedown', handleCustomBlur);
     }
     return () => {
-      document.body.removeEventListener('click', handleCustomBlur);
+      document.body.removeEventListener('mousedown', handleCustomBlur);
     };
   }, [editMode]);
 

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -25,6 +25,7 @@ import {
   AutoLinkPlugin,
   InsertContentMethodPlugin,
   OverrideEnterKeyPlugin,
+  LinkCleanupPlugin,
 } from './plugins';
 import { HashtagSelectorPlugin } from './plugins/HashtagSelector/HashtagSelectorPlugin';
 import {
@@ -76,7 +77,7 @@ function editorOnChange(
   editorState: EditorState,
   editor: LexicalEditor,
   onChange: (html: string) => void,
-  websiteType: 'website' | 'facebook' | 'whatsapp' | 'instagram'
+  linksEnabled: boolean
 ) {
   editorState.toJSON();
   editor.update(() => {
@@ -92,7 +93,7 @@ function editorOnChange(
       // if node is anchor tag, add target blank
       if (node.tagName) {
         if (node.tagName.toLowerCase() === 'a') {
-          if (websiteType === 'website') {
+          if (linksEnabled) {
             node.setAttribute('target', '_blank');
           } else {
             // remove tag an leave only the text link
@@ -133,6 +134,14 @@ export interface EditorProps {
   hideEditButton?: boolean;
   hideEmojis?: boolean;
   hideLink?: boolean;
+  /**
+   * Allow link creation/editing regardless of channel. When omitted, links are
+   * enabled only for `websiteType === 'website'` (legacy behavior). When set
+   * to `false`, any existing LinkNodes in the editor state are converted back
+   * to plain text — useful when toggling between modes (e.g. note vs message
+   * on a channel that doesn't support links).
+   */
+  allowLinks?: boolean;
   selectorsToIgnoreOnBlur?: Array<string>;
   onInsertContentReady?: (content: AddContentToEditorType) => void;
   onEnterKeyPress?: () => void;
@@ -159,6 +168,7 @@ export function Editor({
   hideEditButton,
   hideEmojis,
   hideLink,
+  allowLinks,
   selectorsToIgnoreOnBlur = [],
   onInsertContentReady,
   onEnterKeyPress,
@@ -169,6 +179,7 @@ export function Editor({
   hashtagListOffset,
   onHashtagSelected,
 }: EditorProps) {
+  const linksEnabled = allowLinks ?? websiteType === 'website';
   const Toolbar = useMemo(
     () =>
       !(websiteType === 'instagram' && hideEmojis) ? (
@@ -179,6 +190,7 @@ export function Editor({
           borderless={borderless}
           hideEmojis={hideEmojis}
           hideLink={hideLink}
+          linksEnabled={linksEnabled}
         />
       ) : null,
     [
@@ -188,6 +200,7 @@ export function Editor({
       borderless,
       hideEmojis,
       hideLink,
+      linksEnabled,
     ]
   );
 
@@ -308,13 +321,14 @@ export function Editor({
           <InitialValuePlugin value={initialValue || ''} />
           <LexicalOnChangePlugin
             onChange={(editorState, editor) =>
-              editorOnChange(editorState, editor, onChange, websiteType)
+              editorOnChange(editorState, editor, onChange, linksEnabled)
             }
             ignoreInitialChange
           />
+          <LinkCleanupPlugin linksEnabled={linksEnabled} />
           <HistoryPlugin />
           <ListPlugin />
-          {!hideLink && websiteType === 'website' && (
+          {!hideLink && linksEnabled && (
             <>
               <LinkPlugin />
               <AutoLinkPlugin />

--- a/src/components/Editor/plugins/LinkCleanupPlugin.tsx
+++ b/src/components/Editor/plugins/LinkCleanupPlugin.tsx
@@ -8,11 +8,7 @@ import {
 } from 'lexical';
 import { $isLinkNode } from '@lexical/link';
 
-export function LinkCleanupPlugin({
-  linksEnabled,
-}: {
-  linksEnabled: boolean;
-}) {
+export function LinkCleanupPlugin({ linksEnabled }: { linksEnabled: boolean }) {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {

--- a/src/components/Editor/plugins/LinkCleanupPlugin.tsx
+++ b/src/components/Editor/plugins/LinkCleanupPlugin.tsx
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  $getRoot,
+  $createTextNode,
+  $isElementNode,
+  LexicalNode,
+} from 'lexical';
+import { $isLinkNode } from '@lexical/link';
+
+export function LinkCleanupPlugin({
+  linksEnabled,
+}: {
+  linksEnabled: boolean;
+}) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (linksEnabled) return;
+
+    editor.update(() => {
+      let didReplace = false;
+      const replaceLinkNodes = (node: LexicalNode) => {
+        if ($isLinkNode(node)) {
+          node.replace($createTextNode(node.getTextContent()));
+          didReplace = true;
+          return;
+        }
+        if ($isElementNode(node)) {
+          node.getChildren().forEach(replaceLinkNodes);
+        }
+      };
+      $getRoot()
+        .getChildren()
+        .forEach(replaceLinkNodes);
+      // Selection may have been anchored inside a removed LinkNode. Move it
+      // to the end of the root — a known-valid position. Setting selection to
+      // null instead would crash downstream listeners that read
+      // `selection.anchor` without a null-check (e.g. the hashtag plugin).
+      if (didReplace) {
+        $getRoot().selectEnd();
+      }
+    });
+  }, [linksEnabled, editor]);
+
+  return null;
+}

--- a/src/components/Editor/plugins/LinkCleanupPlugin.tsx
+++ b/src/components/Editor/plugins/LinkCleanupPlugin.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import {
   $getRoot,
+  $getSelection,
+  $isRangeSelection,
   $createTextNode,
   $isElementNode,
   LexicalNode,
@@ -15,11 +17,22 @@ export function LinkCleanupPlugin({ linksEnabled }: { linksEnabled: boolean }) {
     if (linksEnabled) return;
 
     editor.update(() => {
-      let didReplace = false;
+      // Check whether the current selection sits inside a LinkNode before we
+      // start replacing. Only that case requires us to re-anchor the cursor
+      // afterwards; otherwise we leave the user's caret where it was.
+      const selection = $getSelection();
+      let selectionWasInLink = false;
+      if ($isRangeSelection(selection)) {
+        let ancestor: LexicalNode | null = selection.anchor.getNode();
+        while (ancestor !== null && !$isLinkNode(ancestor)) {
+          ancestor = ancestor.getParent();
+        }
+        selectionWasInLink = ancestor !== null;
+      }
+
       const replaceLinkNodes = (node: LexicalNode) => {
         if ($isLinkNode(node)) {
           node.replace($createTextNode(node.getTextContent()));
-          didReplace = true;
           return;
         }
         if ($isElementNode(node)) {
@@ -29,11 +42,12 @@ export function LinkCleanupPlugin({ linksEnabled }: { linksEnabled: boolean }) {
       $getRoot()
         .getChildren()
         .forEach(replaceLinkNodes);
-      // Selection may have been anchored inside a removed LinkNode. Move it
-      // to the end of the root — a known-valid position. Setting selection to
-      // null instead would crash downstream listeners that read
-      // `selection.anchor` without a null-check (e.g. the hashtag plugin).
-      if (didReplace) {
+
+      // Selection was anchored inside a LinkNode we just removed — moving it
+      // to the end of the root keeps it valid. Setting selection to null
+      // would crash downstream listeners that read `selection.anchor` without
+      // a null-check (e.g. the hashtag plugin).
+      if (selectionWasInLink) {
         $getRoot().selectEnd();
       }
     });

--- a/src/components/Editor/plugins/Toolbar/ToolbarPlugin.js
+++ b/src/components/Editor/plugins/Toolbar/ToolbarPlugin.js
@@ -28,7 +28,7 @@ import { getSelectedNode } from './utils/getSelectedNode';
 import { FloatingLinkEditor } from './FloatingLinkEditor.component';
 import { EmojiContainer } from './EmojiContainer.component';
 
-export default function ToolbarPlugin({ embeddedToolbar, hideUndoButtons, hideEmojis, hideLink, borderless, websiteType }) {
+export default function ToolbarPlugin({ embeddedToolbar, hideUndoButtons, hideEmojis, hideLink, borderless, websiteType, linksEnabled }) {
   const [editor] = useLexicalComposerContext();
   const toolbarRef = useRef(null);
   const [canUndo, setCanUndo] = useState(false);
@@ -220,7 +220,7 @@ export default function ToolbarPlugin({ embeddedToolbar, hideUndoButtons, hideEm
         )}
 
         {!hideEmojis && <EmojiContainer />}
-        {!hideLink && !isFacebook && !isInstagram && !isWhatsapp && (
+        {!hideLink && linksEnabled && (
           <>
             <ActionButton name="link" onClick={insertLink} isActive={isLink} />
             {isLink &&

--- a/src/components/Editor/plugins/index.ts
+++ b/src/components/Editor/plugins/index.ts
@@ -3,6 +3,7 @@ import { InsertContentMethodPlugin } from './InsertContentMethodPlugin';
 import { OverrideEnterKeyPlugin } from './OverrideEnterKeyPlugin';
 import AutoLinkPlugin from './AutoLinkPlugin';
 import ToolbarPlugin from './Toolbar/ToolbarPlugin';
+import { LinkCleanupPlugin } from './LinkCleanupPlugin';
 
 export {
   InitialValuePlugin,
@@ -10,4 +11,5 @@ export {
   OverrideEnterKeyPlugin,
   AutoLinkPlugin,
   ToolbarPlugin,
+  LinkCleanupPlugin,
 };


### PR DESCRIPTION
## Contexto

  El editor de wisipoo gatea el comportamiento de los links
  exclusivamente con `websiteType === 'website'`. Esto trae dos problemas
   para consumidores como kanban:

  1. No hay forma de permitir links en *algunos modos* del editor (ej.
  comentarios internos) cuando el canal de la conversación es restrictivo
   (ej. WhatsApp).
  2. Si `websiteType` cambia en runtime, los `LinkNode` que quedaron en
  el estado de Lexical no se limpian hasta el próximo blur — generando
  inconsistencia visual entre lo que se ve y lo que se serializa.

  ## Cambios

  - **`Editor.tsx`** — nuevo prop opcional `allowLinks?: boolean`. Se
  computa `linksEnabled = allowLinks ?? websiteType === 'website'` y se
  usa para gatear `LinkPlugin` / `AutoLinkPlugin`, el handling de `<a>`
  en `editorOnChange`, y el botón del toolbar. **Si no se pasa el prop,
  el comportamiento es idéntico al anterior.**
  - **`LinkCleanupPlugin.tsx`** (nuevo) — al detectar `linksEnabled ===
  false`, recorre el árbol de Lexical y reemplaza cada `LinkNode` por un
  `TextNode` con el mismo texto visible. Mueve la selección al final del
  root para evitar warnings de selección colgada cuando el cursor estaba
  dentro del link removido.
  - **`ToolbarPlugin.js`** — el botón de link ahora se renderiza según
  `linksEnabled` (que ya encapsula la lógica de canal).

  ## Compatibilidad hacia atrás

  | Caso | `allowLinks` | `websiteType` | `linksEnabled` | Comportamiento
   |
  |---|---|---|---|---|
  | Consumidor legacy | (no se pasa) | `'website'` | `true` | Idéntico al
   anterior |
  | Consumidor legacy | (no se pasa) | `'whatsapp'`, `'facebook'`,
  `'instagram'` | `false` | Idéntico al anterior |
  | Consumidor nuevo | `true` | cualquiera | `true` | Permite links sin
  importar el canal |
  | Consumidor nuevo | `false` | cualquiera | `false` | Bloquea y limpia
  links existentes |

  ## Base

  Rebaseado sobre el tag **`1.0.9`**, no sobre `main`. Motivo: kanban
  actualmente consume `#1.0.9` y se evita arrastrar cambios intermedios
  (MaxLengthPlugin, eliminación de TableNode) que llegaron en `1.0.10` y
  `1.0.11` y que no fueron probados con este cambio. Al taggear como
  `1.0.12` después del merge, los proyectos que querían quedarse en 1.0.9
   pueden actualizar sin sorpresas.

  ## Plan de testing

  Probado localmente vía `yarn link` con kanban:
  - WhatsApp + modo nota: URL pegada se convierte a link clickable,
  navegable.
  - WhatsApp + toggle nota → mensaje: el link se convierte a texto plano
  de inmediato (no queda hasta el próximo blur).
  - WhatsApp + modo mensaje (sin pasar `allowLinks`): comportamiento
  original, link button oculto.
  - website (canal default): comportamiento original, link button
  presente.

  ## Notas

  - Lint: 0 errores en archivos modificados. Los 33 errores
  pre-existentes de prettier en otros archivos no se tocan.
  - 2 warnings de `react-hooks/exhaustive-deps` en `Editor.tsx` también
  pre-existentes (no introducidos por este PR).

## Summary by Sourcery

Add configurable control over link support in the editor and ensure link nodes are cleaned up when links are disabled.

New Features:
- Introduce an optional allowLinks prop on the Editor component to enable or disable link support independently of websiteType.
- Expose a linksEnabled flag throughout the editor to control link plugins, toolbar link button visibility, and link handling on change.

Bug Fixes:
- Ensure existing LinkNodes are converted back to plain text when links are disabled, preventing stale links from remaining in the editor state.

Enhancements:
- Add LinkCleanupPlugin to traverse the Lexical tree and remove link nodes when links are not allowed, keeping selection in a valid state.
- Simplify toolbar link button rendering logic by basing it solely on the computed linksEnabled flag instead of channel-specific checks.